### PR TITLE
specifying node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "xunit-file": "~1.0.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": "0.10.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
removed `>=` from engines in package.json